### PR TITLE
Fix issue with sslCA driverOption

### DIFF
--- a/src/ClickHouseConnection.php
+++ b/src/ClickHouseConnection.php
@@ -46,12 +46,19 @@ class ClickHouseConnection implements Connection, PingableConnection, ServerInfo
         string $password,
         AbstractPlatform $platform
     ) {
-        $this->smi2CHClient = new Smi2CHClient([
+        $connectParams = [
             'host' => $params['host'] ?? 'localhost',
             'port' => $params['port'] ?? 8123,
             'username' => $username,
             'password' => $password,
-        ], array_merge([
+        ];
+
+        if (isset($params['driverOptions']['sslCA'])) {
+            $connectParams['sslCA'] = $params['driverOptions']['sslCA'];
+            unset($params['driverOptions']['sslCA']);
+        }
+        
+        $this->smi2CHClient = new Smi2CHClient($connectParams, array_merge([
             'database' => $params['dbname'] ?? 'default',
         ], $params['driverOptions'] ?? []));
         $this->platform = $platform;


### PR DESCRIPTION
When I set sslCA in driverOptions like this:
```yml
clickhouse:
                host:     '%host%'
                port:     '%port%'
                user:     '%username%'
                password: '%password%'
                dbname:   '%name%'
                driver_class: FOD\DBALClickHouse\Driver
                wrapper_class: FOD\DBALClickHouse\Connection
                options:
                    enable_http_compression: 1
                    max_execution_time: 60
                    sslCA: '/usr/local/share/ca-certificates/Yandex/YandexInternalRootCA.crt'
                    https: true
```
I get the next error (`Unknown setting sslCA`):
```bash
bin/console doctrine:migrations:migrate --em=clickhouse --configuration=./app/config/migrations/doctrine_migrations_clickhouse.yml --no-interaction                                                 
Loading configuration from command option: ./app/config/migrations/doctrine_migrations_clickhouse.yml
                                                              
                    Application Migrations                    
                                                              
23:19:31 ERROR     [console] Error thrown while running command "doctrine:migrations:migrate --em=clickhouse --configuration='./app/config/migrations/doctrine_migrations_clickhouse.yml' --no-interaction". Message: "An exception occurred while executing 'SELECT database, name FROM system.tables WHERE database != 'system' AND engine != 'View'':

Unknown setting sslCA 
IN:SELECT database, name FROM system.tables WHERE database != 'system' AND engine != 'View' FORMAT JSON" ["exception" => Doctrine\DBAL\DBALException { …},"command" => "doctrine:migrations:migrate --em=clickhouse --configuration='./app/config/migrations/doctrine_migrations_clickhouse.yml' --no-interaction","message" => """  An exception occurred while executing 'SELECT database, name FROM system.tables WHERE database != 'system' AND engine != 'View'':\n  \n  Unknown setting sslCA \n  IN:SELECT database, name FROM system.tables WHERE database != 'system' AND engine != 'View' FORMAT JSON  """]

In DBALException.php line 172:
                                                                                                                                     
  An exception occurred while executing 'SELECT database, name FROM system.tables WHERE database != 'system' AND engine != 'View'':  
                                                                                                                                     
  Unknown setting sslCA                                                                                                              
  IN:SELECT database, name FROM system.tables WHERE database != 'system' AND engine != 'View' FORMAT JSON
```

This happen because `sslCA` passed in URI

```
https://somecluster.yandex.net:8443?extremes=0&readonly=2&max_execution_time=60&enable_http_compression=1&database=db1&sslCA=%2Fusr%2Flocal%2Fshare%2Fca-certificates%2FYandex%2FYandexInternalRootCA.crt
```
and clickhouse return this error:
```
Code: 115, e.displayText() = DB::Exception: Unknown setting sslCA (version 20.12.3.3 (official build))
```

Also for this parameter to work, it must be passed in `\ClickHouseDB\Client::__construct(connectParams)` 

(currently it passed in `\ClickHouseDB\Client::__construct(settings)`).

I fixed this issues in my fork.


