### PR TITLE
Added query with 'with' support

### DIFF
--- a/src/ClickHouseStatement.php
+++ b/src/ClickHouseStatement.php
@@ -124,7 +124,8 @@ class ClickHouseStatement implements Statement
                 new \ArrayIterator(
                     mb_stripos($statement, 'select') === 0 ||
                     mb_stripos($statement, 'show') === 0 ||
-                    mb_stripos($statement, 'describe') === 0
+                    mb_stripos($statement, 'describe') === 0 ||
+                    preg_match('/with(.*)\)\s*select/ms', mb_strtolower($statement)) == 1
                         ? $this->client->select($statement)->rows()
                         : $this->client->write($statement)->rows()
                 )

--- a/tests/SelectTest.php
+++ b/tests/SelectTest.php
@@ -243,4 +243,20 @@ class SelectTest extends TestCase
 
         $this->assertEquals('t2', $result->fetchOne());
     }
+
+    public function testWith(): void
+    {
+        $result = $this->connection->executeQuery("
+            WITH subselect as (
+                SELECT id
+                FROM test_select_table
+                WHERE payload = 'v4'
+            )
+            SELECT *
+            FROM test_select_table tbl
+            JOIN subselect sub ON sub.id = tbl.id
+        ");
+
+        $this->assertEquals(2, $result->columnCount());
+    }
 }


### PR DESCRIPTION
Fixed issue #27 
This fix allows to use SELECT queries started with WITH.