### PR TITLE
Provide message variable instead of sqlState in Exception

### DIFF
--- a/src/ClickHouseStatement.php
+++ b/src/ClickHouseStatement.php
@@ -129,7 +129,7 @@ class ClickHouseStatement implements Statement
                 )
             );
         } catch (ClickHouseException $exception) {
-            throw new Exception(previous: $exception, sqlState: $exception->getMessage());
+            throw new Exception(previous: $exception, message: $exception->getMessage());
         }
     }
 


### PR DESCRIPTION
Hello

I don't understand why the exception isn't returning "message" variable like everything does.
When trying to try/catch with a $e->getMessage() nothing appears.

I didn't understand why the sqlState is used, maybe if it's useful vars could be duplicated ?