### PR TITLE
Provide message variable in Exception

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -5,8 +5,7 @@ on:
   pull_request:
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-    cancel-in-progress: true
+    group: ${{ github.workflow }}-${{ github.ref_name }}
 
 permissions:
   contents: read
@@ -16,23 +15,35 @@ jobs:
     name: PHPStan
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        php-versions: [8.1]
+
     steps:
-      - name: Checkout
+      - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
-          extensions: pdo
+          php-version: ${{ matrix.php-versions }}
+          extensions: pdo, mbstring, pcre, curl, json
           ini-values: "memory_limit=-1"
-          coverage: none
-          tools: phpstan
+          tools: composer:v2, phpstan
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache composer dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-${{ matrix.php-versions }}-composer-${{ hashFiles('composer.json') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.php-versions }}-composer-
 
       - name: Install dependencies
-        run: |
-          composer config --no-plugins allow-plugins.dealerdirect/phpcodesniffer-composer-installer false
-          composer install --prefer-dist
+        run: composer install --no-progress --prefer-dist --no-interaction
 
-      - name: phpstan
-        run: phpstan analyse -l 5 src
+      - name: Run PHPStan
+        run: phpstan analyse -vvv -l 5 src

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+    group: ${{ github.workflow }}-${{ github.ref_name }}
     cancel-in-progress: true
 
 permissions:
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.1', '8.2', '8.3']
+        php-versions: ['8.1', '8.2', '8.3', '8.4']
       fail-fast: false
 
     services:
@@ -38,11 +38,22 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           extensions: pdo
           ini-values: "memory_limit=-1"
-          tools: composer
+          tools: composer:v2
           coverage: xdebug
 
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache composer dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-${{ matrix.php-versions }}-composer-${{ hashFiles('composer.json') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.php-versions }}-composer-
+
       - name: Install dependencies
-        run: composer install --prefer-dist
+        run: composer install --no-progress --prefer-dist --no-interaction
 
       - name: Run tests
         run: ./vendor/bin/phpunit --configuration ./phpunit.xml.dist --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
     },
     "require-dev": {
         "doctrine/coding-standard": "^4.0 || ^9.0",
-        "phpunit/phpunit": "^9.5 || ^10.0 || ^11.0"
+        "phpunit/phpunit": "^9.5 || ^10.0 || ^11.0",
+        "phpstan/phpstan": "*"
     },
     "autoload": {
         "psr-4": {

--- a/src/ClickHouseSchemaManager.php
+++ b/src/ClickHouseSchemaManager.php
@@ -73,7 +73,7 @@ class ClickHouseSchemaManager extends AbstractSchemaManager
             $matches
         );
 
-        if (is_array($matches) && array_key_exists(2, $matches)) {
+        if (array_key_exists(2, $matches)) {
             $indexColumns = array_filter(
                 array_map('trim', explode(',', $matches[2])),
                 fn (string $column): bool => !str_contains($column, '(')

--- a/src/ClickHouseStatement.php
+++ b/src/ClickHouseStatement.php
@@ -128,8 +128,8 @@ class ClickHouseStatement implements Statement
                         : $this->client->write($statement)->rows()
                 )
             );
-        } catch (ClickHouseException $exception) {
-            throw new Exception(previous: $exception, sqlState: $exception->getMessage());
+        } catch (ClickHouseException $e) {
+            throw new Exception($e->getMessage(), code: $e->getCode(), previous: $e, sqlState: $this->statement);
         }
     }
 


### PR DESCRIPTION
Enhanced thrown Exception:

Passes original message and code from $e.

Keeps $e as previous.

Uses $this->statement as sqlState instead of the exception message.

👉 Provides clearer error context with query, code, and original exception.