### PR TITLE
Provide message variable in Exception

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           extensions: pdo
           ini-values: "memory_limit=-1"
           coverage: none

--- a/src/ClickHouseSchemaManager.php
+++ b/src/ClickHouseSchemaManager.php
@@ -73,7 +73,7 @@ class ClickHouseSchemaManager extends AbstractSchemaManager
             $matches
         );
 
-        if (is_array($matches) && array_key_exists(2, $matches)) {
+        if (array_key_exists(2, $matches)) {
             $indexColumns = array_filter(
                 array_map('trim', explode(',', $matches[2])),
                 fn (string $column): bool => !str_contains($column, '(')

--- a/src/ClickHouseStatement.php
+++ b/src/ClickHouseStatement.php
@@ -128,8 +128,8 @@ class ClickHouseStatement implements Statement
                         : $this->client->write($statement)->rows()
                 )
             );
-        } catch (ClickHouseException $exception) {
-            throw new Exception(previous: $exception, sqlState: $exception->getMessage());
+        } catch (ClickHouseException $e) {
+            throw new Exception($e->getMessage(), code: $e->getCode(), previous: $e, sqlState: $this->statement);
         }
     }
 


### PR DESCRIPTION
Enhanced thrown Exception:

Passes original message and code from $e.

Keeps $e as previous.

Uses $this->statement as sqlState instead of the exception message.

👉 Provides clearer error context with query, code, and original exception.