### PR TITLE
Fix "Can`t find meta" for EXISTS query

### DIFF
--- a/src/ClickHouseStatement.php
+++ b/src/ClickHouseStatement.php
@@ -123,7 +123,8 @@ class ClickHouseStatement implements Statement
                 new \ArrayIterator(
                     mb_stripos($statement, 'select') === 0 ||
                     mb_stripos($statement, 'show') === 0 ||
-                    mb_stripos($statement, 'describe') === 0
+                    mb_stripos($statement, 'describe') === 0 ||
+                    mb_stripos($statement, 'exists') === 0
                         ? $this->client->select($statement)->rows()
                         : $this->client->write($statement)->rows()
                 )

--- a/tests/SelectTest.php
+++ b/tests/SelectTest.php
@@ -248,4 +248,18 @@ class SelectTest extends TestCase
 
         $this->assertEquals('t2', $result->fetchOne());
     }
+
+    public function testExists(): void
+    {
+        $result = $this->connection->executeQuery('EXISTS TABLE test_select_table');
+
+        $this->assertEquals(1, $result->fetchOne());
+    }
+
+    public function testExistsNotExists(): void
+    {
+        $result = $this->connection->executeQuery('EXISTS TABLE non_existent_table');
+
+        $this->assertEquals(0, $result->fetchOne());
+    }
 }


### PR DESCRIPTION
https://clickhouse.com/docs/sql-reference/statements/exists

Otherwise, `EXISTS` is unusable and needs a workaround with `SHOW TABLES LIKE`.